### PR TITLE
fix dataclass for Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Validation has been done on Y, XY, XYYY, and XYXYXY file types. All instances we
 [Wiley's Know It All](https://sciencesolutions.wiley.com/knowitall-spectroscopy-software/) was used also for validating and
 it successfully parsed all formats except XYXYXY, which it states is invalid.
 
-Use Python 3.10.
+Use Python 3.10+.
 
 ## Tests
 
@@ -39,3 +39,12 @@ The newer format specification document:
 
 The older format specification document (has greater detail in parts than newer doc):
 - https://ensembles-eu.metoffice.gov.uk/met-res/aries/technical/GSPC_UDF.PDF
+
+## Changelog
+
+- 2023-10-02 1.0.0
+    - fixed for Python 3.11
+- 2022-12-05 0.2.0
+    - published to PyPi
+- 2022-06-06 0.1.0
+    - initial version

--- a/src/SPyC_Writer/SPCHeader.py
+++ b/src/SPyC_Writer/SPCHeader.py
@@ -22,8 +22,6 @@ class SPCHeader:
     file_type: SPCFileType # (ftflags)
     num_points: int # (fnpts) or directory position for XYXYXY files
     compress_date: SPCDate # (fdate)
-    # x_values: np.ndarray = np.empty(shape=(0))
-    # y_values: np.ndarray = np.empty(shape=(0))
     x_values: np.ndarray = field(default_factory=lambda: np.empty(shape=(0)))
     y_values: np.ndarray = field(default_factory=lambda: np.empty(shape=(0)))
     file_version: int = 0x4B # (fversn)

--- a/src/SPyC_Writer/SPCHeader.py
+++ b/src/SPyC_Writer/SPCHeader.py
@@ -22,8 +22,10 @@ class SPCHeader:
     file_type: SPCFileType # (ftflags)
     num_points: int # (fnpts) or directory position for XYXYXY files
     compress_date: SPCDate # (fdate)
-    x_values: np.ndarray = np.empty(shape=(0))
-    y_values: np.ndarray = np.empty(shape=(0))
+    # x_values: np.ndarray = np.empty(shape=(0))
+    # y_values: np.ndarray = np.empty(shape=(0))
+    x_values: np.ndarray = field(default_factory=lambda: np.empty(shape=(0)))
+    y_values: np.ndarray = field(default_factory=lambda: np.empty(shape=(0)))
     file_version: int = 0x4B # (fversn)
     experiment_type: SPCTechType = SPCTechType.SPCTechGen # (fexper)
     exponent: int = -128 # (fexp)

--- a/src/SPyC_Writer/__init__.py
+++ b/src/SPyC_Writer/__init__.py
@@ -1,3 +1,3 @@
 """ A program to output data in the Thermo Galactic SPC file format."""
 
-__version__ = "0.2.0"
+__version__ = "1.0.0"


### PR DESCRIPTION
Builds, has stopped producing errors. Haven't tested with a spectrometer yet.