### PR TITLE
Adjusted data validation to shape instead of size

### DIFF
--- a/src/SPyC_Writer/SPCFileWriter.py
+++ b/src/SPyC_Writer/SPCFileWriter.py
@@ -138,7 +138,7 @@ class SPCFileWriter:
         self.log_text = log_text
 
     def validate_inputs(self, x_values, y_values, z_values, w_values) -> bool:
-        if x_values.size != 0 and y_values.size != 0 and not (x_values.size == y_values.size):
+        if x_values.size != 0 and y_values.size != 0 and not (x_values.shape[-1] == y_values.shape[-1]):
             log.error(f"got x and y values of different size. Arrays must be so same length.")
             return False
         if x_values.size == 0:


### PR DESCRIPTION
Hi,

I had problems with writing spc files containing multiple subfiles (TMULTI).
As far as I can see with this small change the file is created as expected, but I dont really have in depth knowledge of the spc format, so it is possible that I misunderstood something.

The idea behind it is to validate the shape instead of the size to account for two dimensional `y_values`.
For example for the case that x has length of 350 and there are 70 spectra with the same length of 350, the `y_values` passed to `write_spc_file` would have a shape of (70, 350). Size would result in 70*350 and shape[-1] in 350 as it should be.