### PR TITLE
Rc/package imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,0 @@
-from .src.SPyC_Writer.SPCDate import *
-from .src.SPyC_Writer.SPCEnums import *
-from .src.SPyC_Writer.SPCFileWriter import *
-from .src.SPyC_Writer.SPCHeader import *
-from .src.SPyC_Writer.SPCLog import *
-from .src.SPyC_Writer.SPCSubheader import *

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,6 @@
+from .src.SPyC_Writer.SPCDate import *
+from .src.SPyC_Writer.SPCEnums import *
+from .src.SPyC_Writer.SPCFileWriter import *
+from .src.SPyC_Writer.SPCHeader import *
+from .src.SPyC_Writer.SPCLog import *
+from .src.SPyC_Writer.SPCSubheader import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,6 @@ dynamic = ["version", "description"]
 
 [project.urls]
 Home = "https://github.com/WasatchPhotonics/SPyC_Writer"
+
+[tool.setuptools]
+package-dir = {"" = "src"}

--- a/src/SPyC_Writer/__init__.py
+++ b/src/SPyC_Writer/__init__.py
@@ -1,3 +1,9 @@
 """ A program to output data in the Thermo Galactic SPC file format."""
 
 __version__ = "1.0.1"
+from .SPCDate import *
+from .SPCEnums import *
+from .SPCFileWriter import *
+from .SPCHeader import *
+from .SPCLog import *
+from .SPCSubheader import *


### PR DESCRIPTION
Addresses a pain point observed in this [PR](https://github.com/WasatchPhotonics/SPyC_Writer/issues/7).  Writing `from SPyC_Writer.SPCFileWriter import SPCFileWriter` is verbose and unnecessary. This allows a user to call `from SPyC_Writer import *` and then just write `SPCFileWriter(SPCFileType.DEFAULT)` in order to get an SPCFileWriter object.

<img width="898" height="420" alt="image" src="https://github.com/user-attachments/assets/6797828c-e652-4469-9564-30d73f0088f6" />
